### PR TITLE
fix link to object-flow options in general README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ This module expects three fields on the passed `options` object: `.srcBucket`, `
 
 It will download an object to the specified filepath from the specifed S3 bucket and key. 
 
-NOTE: See the [general Lambduh README]() for info on the `options` object flow. (In short, an `options` object is expected to flow through the full promise chain, and modules are expected to act on it or pass it on, or both).
+NOTE: See the [general Lambduh README](https://github.com/lambduh/lambduh#usage---options-object-flow) for info on the `options` object flow. (In short, an `options` object is expected to flow through the full promise chain, and modules are expected to act on it or pass it on, or both).
 
 # Full disclosure
 
 This module's tests don't yet cover the `aws-sdk` implementation - only the validation and other basic things.
+
 I'm hoping to get back to this soon....


### PR DESCRIPTION
Noticed that this link didn't take me where I expected to go.

I went ahead and made it link to the heading that you were referring to, but you may have wanted to just link to the page itself.

Let me know.  :)
