### PR TITLE
Allow user to specify region of S3 Bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ exports.handler = function(event, context) {
 
 This module expects three fields on the passed `options` object: `.srcBucket`, `.srcKey`, and `.downloadFilepath`
 
-It will download an object to the specified filepath from the specifed S3 bucket and key.
+By default this will use the default region the lambda operates in.  If you need to operate on an S3 bucket in another region you can set the region field on the `options` object: `.region`.
+
+It will download an object to the specified filepath from the specifed S3 bucket, key and region (if specified).
 
 Note: for whatever reason, this func is resolving before the stream is
 completely finished. In practice, I'm solving this with a 500ms timeout.

--- a/index.js
+++ b/index.js
@@ -27,7 +27,12 @@ module.exports = function(result, options) {
     };
 
     var file = fs.createWriteStream(options.downloadFilepath)
-    var S3 = new AWS.S3({params: params});
+
+    if (options.region) {
+      var S3 = new AWS.S3({params: params, region: options.region});
+    } else {
+      var S3 = new AWS.S3({params: params});
+    }
 
     var downloadProgress = 0;
     var readStream = S3.getObject().createReadStream();


### PR DESCRIPTION
Hi,

The region I have my S3 buckets in unfortunately does not support AWS lambda. I have made a minor change to your module to support specifying the region for the s3 bucket.

This should only be a minor version bump as I made it optional to specify the region.

Thanks,

Peter.
