### PR TITLE
Fix race-condition in download

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,6 @@ By default this will use the default region the lambda operates in.  If you need
 
 It will download an object to the specified filepath from the specifed S3 bucket, key and region (if specified).
 
-Note: for whatever reason, this func is resolving before the stream is
-completely finished. In practice, I'm solving this with a 500ms timeout.
-Which sucks, but has been good enough for now.
-
 # Full disclosure
 
 This module's tests don't yet cover the `aws-sdk` implementation - only the validation and other basic things.

--- a/index.js
+++ b/index.js
@@ -43,12 +43,12 @@ module.exports = function(result, options) {
         console.log('downloadProgress: ' + downloadProgress);
       }
     });
-    readStream.on('end', function() {
-      console.log('downloaded: ' + params.Key);
-      def.resolve(result);
-    });
     readStream.on('error', function(err) {
       def.reject(err);
+    });
+    file.on('close', function () {
+      console.log('downloaded: ' + params.Key);
+      def.resolve(result);
     });
     readStream.pipe(file);
 


### PR DESCRIPTION
Previously this was waiting for the `end` event on the read stream. Instead it should wait for the `close` event on the file stream. This is important because after we get to the end of the read stream, we're still writing the changes to disk on the file/write stream.

https://nodejs.org/api/stream.html#stream_event_close_1